### PR TITLE
added query argument for download functions

### DIFF
--- a/R/cbs4_download.R
+++ b/R/cbs4_download.R
@@ -7,6 +7,7 @@
 #'
 #' @param id Identifier of publication
 #' @param download_dir directory where files are to be stored
+#' @param query odata4 query (overwrites any specification in `...`)
 #' @param ... optional selection statement to retrieve a subset of the data.
 #' @param catalog Catalog to download from
 #' @param sep seperator to be used in writing the data
@@ -18,6 +19,7 @@
 #' @family data-download
 cbs4_download <- function( id
                          , download_dir = id
+                         , query = NULL
                          , ...
                          , catalog = "CBS"
                          , show_progress = interactive() && !verbose
@@ -45,8 +47,13 @@ cbs4_download <- function( id
   }
 
   path <- file.path(base_url, catalog, id, "Observations")
-  path <- paste0(path, get_query(..., .meta = meta))
-  path <- utils::URLencode(path)
+  if (is.null(query)) {
+    path <- paste0(path, get_query(..., .meta = meta))
+  } else {
+    path <- paste0(path, '?', query)
+  }
+  path <- utils::URLencode(path
+  )
 
   path_obs <- file.path(download_dir, "Observations.csv")
 
@@ -99,5 +106,8 @@ get_empty_data.frame <- function(meta){
 
 # id <- "84120NED"
 # m <- cbs4_download("84120NED", verbose = T)
+# m <- cbs4_download("84120NED",
+#   query="$skip=5&$top=20&$select=Measure,Value,Perioden,BelastingenEnWettelijkePremies",
+#   verbose = T)
 # cbs4_download("83765NED", verbose = T)
 # cbs4_download("81575NED", verbose = T)

--- a/R/cbs4_get_data.R
+++ b/R/cbs4_get_data.R
@@ -13,6 +13,7 @@
 #' @seealso [cbs4_get_metadata()]
 cbs4_get_data <- function( id
                          , catalog = "CBS"
+                         , query = NULL
                          , ...
                          , name_measure_columns = TRUE
                          , show_progress = interactive() && !verbose
@@ -25,6 +26,7 @@ cbs4_get_data <- function( id
 
   obs <- cbs4_get_observations(id = id
                               , catalog = catalog
+                              , query = query
                               , ...
                               , download_dir = download_dir
                               , verbose = verbose

--- a/R/cbs4_get_observations.R
+++ b/R/cbs4_get_observations.R
@@ -10,6 +10,7 @@
 #' @export
 #' @param id Identifier of the Opendata table. Can be retrieved with [cbs4_get_datasets()]
 #' @param catalog Catalog in which the dataset is to be found.
+#' @param query odata4 query (overwrites any specification in `...`)
 #' @param ... optional selections on data, passed through to cbs4_download. See examples
 #' @param download_dir directory in which the data and metadata is downloaded. By default this is
 #' temporary directory, but can be set manually
@@ -23,6 +24,7 @@
 #' @family data-download
 #' @seealso [cbs4_get_metadata()]
 cbs4_get_observations <- function( id
+                                 , query = NULL
                                  , ...
                                  , catalog = "CBS"
                                  , download_dir = file.path(tempdir(), id)
@@ -40,6 +42,7 @@ cbs4_get_observations <- function( id
 
   meta <- cbs4_download( id
                        , catalog = catalog
+                       , query = query
                        , ...
                        , download_dir = download_dir
                        , verbose = verbose

--- a/example/query.R
+++ b/example/query.R
@@ -45,4 +45,14 @@ if (interactive()){
                        , Measure   = "M003371_2"
                        )
 
+  # With query argument an odata4 expression with other (filter) functions can be used
+  cbs4_get_observations(
+    id     = "80784ned"    # table id
+    ,query = paste0(       # odata4 query
+       "$skip=4",          # skip the first 4 rows of the filtered result
+       "&$top=20",         # then slice the first 20 rows of the filtered result
+       "&$select=Measure,Geslacht,Perioden,RegioS,Value", # omit the Id and ValueAttribute fields
+       "&$filter=endswith(Measure,'_1')") # filter only Measure ending on '_1'
+    )
+
 }

--- a/man/cbs4_download.Rd
+++ b/man/cbs4_download.Rd
@@ -7,6 +7,7 @@
 cbs4_download(
   id,
   download_dir = id,
+  query = NULL,
   ...,
   catalog = "CBS",
   show_progress = interactive() && !verbose,
@@ -19,6 +20,8 @@ cbs4_download(
 \item{id}{Identifier of publication}
 
 \item{download_dir}{directory where files are to be stored}
+
+\item{query}{odata4 query (overwrites any specification in \code{...})}
 
 \item{...}{optional selection statement to retrieve a subset of the data.}
 

--- a/man/cbs4_get_data.Rd
+++ b/man/cbs4_get_data.Rd
@@ -7,6 +7,7 @@
 cbs4_get_data(
   id,
   catalog = "CBS",
+  query = NULL,
   ...,
   name_measure_columns = TRUE,
   show_progress = interactive() && !verbose,
@@ -21,6 +22,8 @@ cbs4_get_data(
 \item{id}{Identifier of the Opendata table. Can be retrieved with \code{\link[=cbs4_get_datasets]{cbs4_get_datasets()}}}
 
 \item{catalog}{Catalog in which the dataset is to be found.}
+
+\item{query}{odata4 query (overwrites any specification in \code{...})}
 
 \item{...}{optional selections on data, passed through to cbs4_download. See examples}
 
@@ -93,6 +96,16 @@ if (interactive()){
                        , RegioS    = contains("PV")
                        , Measure   = "M003371_2"
                        )
+
+  # With query argument an odata4 expression with other (filter) functions can be used
+  cbs4_get_observations(
+    id     = "80784ned"    # table id
+    ,query = paste0(       # odata4 query
+       "$skip=4",          # skip the first 4 rows of the filtered result
+       "&$top=20",         # then slice the first 20 rows of the filtered result
+       "&$select=Measure,Geslacht,Perioden,RegioS,Value", # omit the Id and ValueAttribute fields
+       "&$filter=endswith(Measure,'_1')") # filter only Measure ending on '_1'
+    )
 
 }
 }

--- a/man/cbs4_get_observations.Rd
+++ b/man/cbs4_get_observations.Rd
@@ -6,6 +6,7 @@
 \usage{
 cbs4_get_observations(
   id,
+  query = NULL,
   ...,
   catalog = "CBS",
   download_dir = file.path(tempdir(), id),
@@ -19,6 +20,8 @@ cbs4_get_observations(
 }
 \arguments{
 \item{id}{Identifier of the Opendata table. Can be retrieved with \code{\link[=cbs4_get_datasets]{cbs4_get_datasets()}}}
+
+\item{query}{odata4 query (overwrites any specification in \code{...})}
 
 \item{...}{optional selections on data, passed through to cbs4_download. See examples}
 
@@ -94,6 +97,16 @@ if (interactive()){
                        , RegioS    = contains("PV")
                        , Measure   = "M003371_2"
                        )
+
+  # With query argument an odata4 expression with other (filter) functions can be used
+  cbs4_get_observations(
+    id     = "80784ned"    # table id
+    ,query = paste0(       # odata4 query
+       "$skip=4",          # skip the first 4 rows of the filtered result
+       "&$top=20",         # then slice the first 20 rows of the filtered result
+       "&$select=Measure,Geslacht,Perioden,RegioS,Value", # omit the Id and ValueAttribute fields
+       "&$filter=endswith(Measure,'_1')") # filter only Measure ending on '_1'
+    )
 
 }
 }

--- a/man/contains.Rd
+++ b/man/contains.Rd
@@ -66,6 +66,16 @@ if (interactive()){
                        , Measure   = "M003371_2"
                        )
 
+  # With query argument an odata4 expression with other (filter) functions can be used
+  cbs4_get_observations(
+    id     = "80784ned"    # table id
+    ,query = paste0(       # odata4 query
+       "$skip=4",          # skip the first 4 rows of the filtered result
+       "&$top=20",         # then slice the first 20 rows of the filtered result
+       "&$select=Measure,Geslacht,Perioden,RegioS,Value", # omit the Id and ValueAttribute fields
+       "&$filter=endswith(Measure,'_1')") # filter only Measure ending on '_1'
+    )
+
 }
 }
 \seealso{

--- a/man/eq.Rd
+++ b/man/eq.Rd
@@ -69,6 +69,16 @@ if (interactive()){
                        , Measure   = "M003371_2"
                        )
 
+  # With query argument an odata4 expression with other (filter) functions can be used
+  cbs4_get_observations(
+    id     = "80784ned"    # table id
+    ,query = paste0(       # odata4 query
+       "$skip=4",          # skip the first 4 rows of the filtered result
+       "&$top=20",         # then slice the first 20 rows of the filtered result
+       "&$select=Measure,Geslacht,Perioden,RegioS,Value", # omit the Id and ValueAttribute fields
+       "&$filter=endswith(Measure,'_1')") # filter only Measure ending on '_1'
+    )
+
 }
 }
 \seealso{


### PR DESCRIPTION
The query argument allows the use of all odata4 query possibilities.
When used it overwrites the `eq` and `contains` filter options now supported as `'...'`